### PR TITLE
Update GitHub Actions workflow to work with budibase releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,19 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: bb-component-SuperTableColumn
+      - uses: actions/checkout@v3
+        with:
+          repository: nutgood/bb-component-SuperTableCell
+          ref: main
+          path: bb-component-SuperTableCell
       - uses: actions/setup-node@v1
         with:
           node-version: 16
       - name: Make the production plugin bundle
         run: |
+          cd bb-component-SuperTableColumn
           release_version=$(cat package.json | jq -r '.version')
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
           yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,10 @@ jobs:
           path: bb-component-SuperTableColumn
       - uses: actions/checkout@v3
         with:
-          repository: nutgood/bb-component-SuperTableCell
+          repository: poirazis/bb-component-SuperTableCell
           ref: main
           path: bb-component-SuperTableCell
+          
       - uses: actions/setup-node@v1
         with:
           node-version: 16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - master
       - main
 
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/lib/SuperTableColumn/parts/SuperColumnRow.svelte
+++ b/lib/SuperTableColumn/parts/SuperColumnRow.svelte
@@ -3,7 +3,7 @@
 	import { elementSizeStore } from "svelte-legos";
 	const { Provider } = getContext("sdk")
 
-	import { SuperTableCell } from "../../../bb-component-SuperTableCell/lib/SuperTableCell/index.js";
+	import { SuperTableCell } from "../../../../bb-component-SuperTableCell/lib/SuperTableCell/index.js";
 
 	const dispatch = createEventDispatcher();
 


### PR DESCRIPTION
Hello !

I updated your github actions workflow so that it builds plugins releases by itself again.

I was unable to get the submodule approach working, so instead, I'm using parallel cloning.

Basically, instead of the tree being like this:
```
bb-component-SuperTable/
   bb-component-SuperTableColumn/
       bb-component-SuperTableCell/
```

It is like this:
```
github-actions/
    bb-component-SuperTable/
    bb-component-SuperTableColumn/
    bb-component-SuperTableCell/
```

I've had to update both the SuperTable and SuperTableColumn repoes so there is PRs in both of them, I would recommend merging the column one before you merge the table one.

Also the history is not particularly clean, but that is due to me trying out submodules and the fact that you can't test gihub actions workflows easily.

